### PR TITLE
add a few missing (void) to please clang

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -179,7 +179,7 @@ static lsec_ssl_option_t ssl_options[] = {
   {NULL, 0L}
 };
 
-LSEC_API lsec_ssl_option_t* lsec_get_ssl_options() {
+LSEC_API lsec_ssl_option_t* lsec_get_ssl_options(void) {
   return ssl_options;
 }
 

--- a/src/options.h
+++ b/src/options.h
@@ -17,6 +17,6 @@ struct lsec_ssl_option_s {
 
 typedef struct lsec_ssl_option_s lsec_ssl_option_t;
 
-LSEC_API lsec_ssl_option_t* lsec_get_ssl_options();
+LSEC_API lsec_ssl_option_t* lsec_get_ssl_options(void);
 
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -42,7 +42,7 @@
 /**
  * Underline socket error.
  */
-static int lsec_socket_error()
+static int lsec_socket_error(void)
 {
 #if defined(WIN32)
   return WSAGetLastError();


### PR DESCRIPTION
Spotted building with clang 16.  The warnings are:

```
./options.h:20:49: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
LSEC_API lsec_ssl_option_t* lsec_get_ssl_options();
                                                ^
                                                 void
```

etc.

With this applied, it builds without warnings on OpenBSD-CURRENT w/ clang 16.0.6