### PR TITLE
fix(windows): remove non-implemented sentinel value

### DIFF
--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -85,12 +85,7 @@ local find_system_ca do
       "/etc/ssl/cert.pem",                                  -- OpenBSD / Alpine / macOS
    }
 
-   local is_windows = package.config:sub(1, 1) == "\\"
-
    function find_system_ca()
-      if is_windows then
-         return "system"
-      end
       for _, path in ipairs(ca_bundle_paths) do
          local fh = io.open(path, "r")
          if fh then


### PR DESCRIPTION
The intent was to implement a Windows specific CA lookup. But due to Windows dynamic lookup/download and caching features that is too complex. And this sentinel value got accidentally left behind.