### PR TITLE
fix(ssl): reject cfg.host in newcontext

### DIFF
--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -138,6 +138,10 @@ end
 --
 local function newcontext(cfg)
    local succ, msg, ctx
+   if cfg.host then
+      return nil, "cfg.host is not supported by newcontext; " ..
+         "for automatic hostname verification use ssl.wrap instead"
+   end
    -- Create the context
    ctx, msg = context.create(cfg.protocol)
    if not ctx then return nil, msg end
@@ -320,7 +324,9 @@ local function wrap(sock, cfg)
          return nil, "cfg.host must not be combined with cfg.dane; " ..
             "DANE clients must set the peer hostname via conn:setdane(host) instead"
       end
+      cfg.host = nil
       ctx, msg = newcontext(cfg)
+      cfg.host = host
       if not ctx then return nil, msg end
    else
       ctx = cfg


### PR DESCRIPTION
cfg.host/cfg.hostflags only take effect in ssl.wrap, which applies them via sethost()/sethostflags() after the context is created. Passing them to ssl.newcontext directly was silently ignored, which could lead users to believe hostname verification was enabled when it wasn't.

newcontext now errors if cfg.host is set. wrap() temporarily clears cfg.host before delegating to newcontext and restores it afterward, since it applies host verification itself. Checking cfg.hostflags is not necessary since it has no effect without cfg.host.

Fixes #218