### PR TITLE
Fix ALPN and DH parameter leaks during TLS handshakes

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -652,6 +652,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
                    const unsigned char *in, unsigned int inlen, void *arg)
 {
   int ret;
+  unsigned int pos, len;
   size_t server_len;
   const char *server;
   p_context ctx = (p_context)arg;
@@ -679,14 +680,24 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
     return SSL_TLSEXT_ERR_NOACK;
   } 
 
-  // Copy the result because lua_pop() can collect the pointer
-  ctx->alpn = malloc(*outlen);
-  memcpy(ctx->alpn, (void*)*out, *outlen);
-  *out = (const unsigned char*)ctx->alpn;
+  /* Use the matching bytes in OpenSSL's input buffer so the Lua string
+   * can be collected. OpenSSL permits out to point directly into in:
+   * https://docs.openssl.org/3.0/man3/SSL_CTX_set_alpn_select_cb/#description
+   */
+  for (pos = 0; pos < inlen; pos += len) {
+    len = in[pos++];
+    if (len == 0 || len > inlen - pos)
+      break;
+    if (len == *outlen && memcmp(in + pos, *out, len) == 0) {
+      *out = in + pos;
+      lua_pop(L, 2);
+      return SSL_TLSEXT_ERR_OK;
+    }
+  }
 
+  /* A negotiated protocol must exist in the client list. */
   lua_pop(L, 2);
-
-  return SSL_TLSEXT_ERR_OK;
+  return SSL_TLSEXT_ERR_ALERT_FATAL;
 }
 
 /**

--- a/src/context.h
+++ b/src/context.h
@@ -24,7 +24,6 @@ typedef struct t_context_ {
   SSL_CTX *context;
   lua_State *L;
   DH *dh_param;
-  void *alpn;
   int mode;
 } t_context;
 typedef t_context* p_context;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -401,10 +401,6 @@ static int meth_handshake(lua_State *L)
     DH_free(selected_ctx->dh_param);
     selected_ctx->dh_param = NULL;
   }
-  if (ctx->alpn) {
-    free(ctx->alpn);
-    ctx->alpn = NULL;
-  }
   if (err == IO_DONE) {
     lua_pushboolean(L, 1);
     return 1;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -386,6 +386,7 @@ static int meth_setfd(lua_State *L)
 static int meth_handshake(lua_State *L)
 {
   int err;
+  p_context selected_ctx;
   p_ssl ssl = (p_ssl)luaL_checkudata(L, 1, "SSL:Connection");
   p_context ctx = (p_context)SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl->ssl));
   ctx->L = L;
@@ -393,6 +394,12 @@ static int meth_handshake(lua_State *L)
   if (ctx->dh_param) {
     DH_free(ctx->dh_param);
     ctx->dh_param = NULL;
+  }
+  /* SNI may have selected a different context for the DH callback. */
+  selected_ctx = (p_context)SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl->ssl));
+  if (selected_ctx != ctx && selected_ctx->dh_param) {
+    DH_free(selected_ctx->dh_param);
+    selected_ctx->dh_param = NULL;
   }
   if (ctx->alpn) {
     free(ctx->alpn);


### PR DESCRIPTION
Found this slow-but-steady memory leak on a long running Prosody server we were investigating.

Two fixes:

1. Free DH parameters on the SNI-selected context as well as the original context. The DH callback uses the selected context, which the existing cleanup misses.
2. Return the selected ALPN bytes from OpenSSL's input buffer, preserving server preference. This removes the allocation that leaks after SNI context changes or repeated HelloRetryRequest callbacks.

[OpenSSL documents this](https://docs.openssl.org/3.0/man3/SSL_CTX_set_alpn_select_cb/#description):

> The out buffer may point directly into in, or to a buffer that outlives the handshake.

Other examples: [nghttp2](https://github.com/nghttp2/nghttp2/blob/a9a495931cd74d13cbd0845652d8712c58358dca/lib/nghttp2_alpn.c#L31-L43), [ngtcp2's OpenSSL server example](https://github.com/ngtcp2/ngtcp2/blob/72a85865dd3a4b33fe5830baf461ed50ebb7ad0e/examples/tls_server_context_ossl.cc#L55-L82), [libwebsockets' QUIC ALPN path](https://github.com/warmcat/libwebsockets/blob/6ee32ad13cd9d0e77c3c55f48c4080bb148504f6/lib/tls/tls.c#L178-L204), [Node.js](https://github.com/nodejs/node/blob/v22.14.0/src/crypto/crypto_tls.cc#L283-L291), and [NTPsec](https://github.com/ntpsec/ntpsec/blob/master/ntpd/nts_server.c#L83).

I tested unpatched master and these changes with Valgrind, Lua 5.4.4 and OpenSSL 3.0.20 under docker. The following cases leaked before and no longer do:

- SNI switches: TLS 1.2/1.3 ALPN and blocking DHE, including aborted handshakes
- HelloRetryRequest with and without SNI selection, including nonblocking and overlapping handshakes
- ALPN server preference and binary/long names
